### PR TITLE
Release/6.0.0: Linking to Documentation instead of wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A powerful and elegant C# library for Razer Chroma's SDK
 Getting started
 ---------------
 
-If you are a new developer and are looking for a helpful guide on how to get started, head on over to
+If you are a new developer and are looking for a helpful guide on how to get started, head on over to the [Documentation](https://chroma-sdk.github.io/Colore/docs/articles/getting-started.html)
 [the wiki page][getting-started] which describes getting Colore installed and running some example code.
 
 Contributing

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A powerful and elegant C# library for Razer Chroma's SDK
 Getting started
 ---------------
 
-If you are a new developer and are looking for a helpful guide on how to get started, head on over to the [Documentation](https://chroma-sdk.github.io/Colore/docs/articles/getting-started.html) which describes getting Colore installed and running some example code.
+If you are a new developer and are looking for a helpful guide on how to get started, head on over to the [documentation](https://chroma-sdk.github.io/Colore/docs/articles/getting-started.html) which describes getting Colore installed and running some example code.
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ A powerful and elegant C# library for Razer Chroma's SDK
 Getting started
 ---------------
 
-If you are a new developer and are looking for a helpful guide on how to get started, head on over to the [Documentation](https://chroma-sdk.github.io/Colore/docs/articles/getting-started.html)
-[the wiki page][getting-started] which describes getting Colore installed and running some example code.
+If you are a new developer and are looking for a helpful guide on how to get started, head on over to the [Documentation](https://chroma-sdk.github.io/Colore/docs/articles/getting-started.html) which describes getting Colore installed and running some example code.
 
 Contributing
 ------------


### PR DESCRIPTION
The wiki has less documentation than the gh-pages. So let people know that there is also https://chroma-sdk.github.io/Colore/