### PR TITLE
Changed to use appveyor build number instead of version

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -347,7 +347,7 @@ Task("Codecov")
     .IsDependentOn("Test")
     .Does(() =>
     {
-        var ccVersion = $"{version.FullSemVer}.build.{BuildSystem.AppVeyor.Environment.Build.Version}";
+        var ccVersion = $"{version.FullSemVer}.build.{BuildSystem.AppVeyor.Environment.Build.Number}";
         var codecovPath = Context.Tools.Resolve("codecov.exe");
 
         Information("Running Codecov tool with version {0} on OpenCover result", ccVersion);


### PR DESCRIPTION
Due to incorrect documentation in the Cake.Codecov library, Appveyor.Version was incorrectly used instead of Appveyor.Number.

This Pull Request changes that to the correct variant.