### PR TITLE
Fix dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The following games (powered by Unity) are using Colore:
 Projects using Colore
 ---------------------
 
-[Aurora](http://aurora.lastbullet.net/) - Unified lighting effects across multiple brands and various games. ([GitHub](https://github.com/antonpup/Aurora))
+[Aurora](http://www.project-aurora.com/) - Unified lighting effects across multiple brands and various games. ([GitHub](https://github.com/antonpup/Aurora))
 
 There may be others we are unaware of, so please let us know if there are any others.
 


### PR DESCRIPTION
The Aurora Project has moved domains. 
http://www.project-aurora.com/ is the current one. This changes the dead link in the README to this.